### PR TITLE
Support relocating python prefix

### DIFF
--- a/venv_pack/__main__.py
+++ b/venv_pack/__main__.py
@@ -10,7 +10,7 @@ from .core import pack, VenvPackException
 
 class MultiAppendAction(argparse.Action):
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        if nargs is not None:
+        if nargs is not None:  # pragma: nocover
             raise ValueError("nargs not allowed")
         super(MultiAppendAction, self).__init__(option_strings, dest, **kwargs)
 
@@ -128,10 +128,10 @@ def main(args=None, pack=pack):
         fail("VenvPackError: %s" % e)
     except KeyboardInterrupt as e:  # pragma: nocover
         fail("Interrupted")
-    except Exception as e:
+    except Exception as e:  # pragma: nocover
         fail(traceback.format_exc())
     sys.exit(0)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: nocover
     main()

--- a/venv_pack/__main__.py
+++ b/venv_pack/__main__.py
@@ -43,6 +43,13 @@ def build_parser():
                         default='infer',
                         help=("The archival format to use. By default this is "
                               "inferred by the output file extension."))
+    parser.add_argument("--python-prefix",
+                        metavar="PATH",
+                        help=("If provided, will be used as the new prefix path "
+                              "for linking ``python`` in the packaged "
+                              "environment. Note that this is the path to the "
+                              "*prefix*, not the path to the *executable* (e.g. "
+                              "``/usr/`` not ``/usr/lib/python3.6``)."))
     parser.add_argument("--compress-level",
                         type=int,
                         default=4,
@@ -110,6 +117,7 @@ def main(args=None, pack=pack):
         pack(prefix=args.prefix,
              output=args.output,
              format=args.format,
+             python_prefix=args.python_prefix,
              force=args.force,
              compress_level=args.compress_level,
              zip_symlinks=args.zip_symlinks,

--- a/venv_pack/core.py
+++ b/venv_pack/core.py
@@ -50,7 +50,7 @@ class AttrDict(dict):
     def __getattr__(self, key):
         try:
             return self[key]
-        except KeyError:
+        except KeyError:  # pragma: nocover
             raise AttributeError(key)
 
 
@@ -401,7 +401,7 @@ def check_venv(prefix):
             if key.strip().lower() == 'home':
                 orig_prefix = os.path.dirname(val.strip())
                 break
-        else:
+        else:  # pragma: nocover
             raise VenvPackException("%r is not a valid virtual "
                                     "environment" % prefix)
 
@@ -466,7 +466,7 @@ def check_no_editable_packages(context):
         dirname = os.path.dirname(pth_fil)
         with open(pth_fil) as pth:
             for line in pth:
-                if line.startswith('#'):
+                if line.startswith('#'):  # pragma: nocover
                     continue
                 line = line.rstrip()
                 if line:
@@ -541,7 +541,7 @@ def rewrite_shebang(data, target, prefix):
     prefix_b = prefix.encode('utf-8')
 
     if shebang_match:
-        if data.count(prefix_b) > 1:
+        if data.count(prefix_b) > 1:  # pragma: nocover
             # More than one occurrence of prefix, can't fully cleanup.
             return data, False
 

--- a/venv_pack/formats.py
+++ b/venv_pack/formats.py
@@ -70,7 +70,12 @@ class ZipArchive(object):
 
     def add_link(self, source, sourcelink, target, st=None):
         if not self.zip_symlinks:
-            raise ValueError("Can't add a symlink with zip-links disabled")
+            # Links aren't supported, add the original file directly. This is
+            # fine, since the target link file must be identical to the source
+            # for relocation to be robust anyway.
+            self.add(source, target)
+            return
+
         if st is None:
             st = os.lstat(source)
         info = zipfile.ZipInfo(target)
@@ -84,7 +89,7 @@ class ZipArchive(object):
         try:
             st = os.lstat(source)
             is_link = stat.S_ISLNK(st.st_mode)
-        except (OSError, AttributeError):
+        except (OSError, AttributeError):  # pragma: nocover
             is_link = False
 
         if is_link:


### PR DESCRIPTION
Supports changing the prefix path to the linked python. This is useful when the location of python on the source machine is different than on the destination machine.