### PR TITLE
Git Bash on Windows support fixed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,9 @@ ignore =
     # Comparing types instead of isinstance
     E721,
     # Ambiguous variable names
-    E741
+    E741,
+    # Line break after binary operator
+    W504
 max-line-length = 90
 
 [versioneer]

--- a/venv_pack/__main__.py
+++ b/venv_pack/__main__.py
@@ -126,9 +126,9 @@ def main(args=None, pack=pack):
              filters=args.filters)
     except VenvPackException as e:
         fail("VenvPackError: %s" % e)
-    except KeyboardInterrupt as e:  # pragma: nocover
+    except KeyboardInterrupt:  # pragma: nocover
         fail("Interrupted")
-    except Exception as e:  # pragma: nocover
+    except Exception:  # pragma: nocover
         fail(traceback.format_exc())
     sys.exit(0)
 

--- a/venv_pack/core.py
+++ b/venv_pack/core.py
@@ -623,7 +623,7 @@ class Packer(object):
         script_dirs = ['common']
         if on_win:
             # TODO: windows
-            script_dirs.append('nt')
+            pass
         for d in script_dirs:
             dirpath = os.path.join(SCRIPTS, d)
             for f in os.listdir(dirpath):


### PR DESCRIPTION
This fixes the failure due to missing `nt` path on Windows Git Bash.