### PR TITLE
CI builds on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: minimal
 sudo: false
 os: linux
 
-branches:
-    only:
-        - master
-
 env:
     global:
         - secure: "mwAefLGtK0kTgstNU8/xVpoEleRZLpWZr2xBlhMr4H/3lPkNrKQno1I6PT5ADdvDtJeLo0jBKaH9Ooe+IYZovo1J5qY0YEEpSFdpovHOyAPO/YAA8fzoWT8IIhbU9/4YNGsQ3Ldvvtl0oSsCuyIl4Iopc2gBHlJHakhQQ0ILuCGHmQ6faqk+WUPioEfVjSjmzKQb7gFZRXszZueDxnljiDfL4txZyDMwQd5sQuok+F37cAdncrwnGa+bwcSOQSdrdsBIL2nmnEsaD9q+7cRk9uotn7Qf4ICcq12PChK6/LazeNTmeU2SR3HO0Wo74XU1WuDzvYdFwNZ6D6B4VnkvSgB+hl/x62P4JW8R1Y/dvsvI90vaNKnJFjrIOV6uhiTrf5TXVVfsivYhdGYotzgLjFK7fm6MCwNhagACl5NMTyGAAwK4QBFD+U9YxPOQbKIbdt1FAZsFcp0FZos/WCtiWIG7zQQkcsHfklwmDaCVZ7zMCC7+XmustMS34gUJHXDlqCNbYcMiuj7Ybn2QAbfRrVJAJtOHDqqmEOBjIHfr6srPO4q4jHJqVdZ4fM1hvDizzWLXqObyH9KrijD0crygEtmpzwJUq435ZzwzZM6GhFHP0UrtuVF4d9PAKhxa50nUAl0YI+m/KNU2Mh2yvgeLzllVUbeB7NO0gmBNhJuZ98Q="


### PR DESCRIPTION
Removes the restriction to execute CI builds only on the master branch. This enables feedback while developing.

The doc generation remains master-only.