### PR TITLE
Add keep_symlinks option and disable it by default

### DIFF
--- a/venv_pack/__main__.py
+++ b/venv_pack/__main__.py
@@ -59,16 +59,8 @@ def build_parser():
                               "``format='zip'``. Default is 4."))
     parser.add_argument("--zip-symlinks",
                         action="store_true",
-                        help=("Symbolic links aren't supported by the Zip "
-                              "standard, but are supported by *many* common "
-                              "Zip implementations. If set, store symbolic "
-                              "links in the archive, instead of the file "
-                              "referred to by the link. This can avoid storing "
-                              "multiple copies of the same files. *Note that "
-                              "the resulting archive may silently fail on "
-                              "decompression if the ``unzip`` implementation "
-                              "doesn't support symlinks*. Ignored if format "
-                              "isn't ``zip``."))
+                        help=argparse.SUPPRESS,
+                        default=None)  # Deprecated.
     parser.add_argument("--no-zip-64",
                         action="store_true",
                         help="Disable ZIP64 extensions.")
@@ -93,6 +85,17 @@ def build_parser():
     parser.add_argument("--version",
                         action='store_true',
                         help="Show version then exit")
+    parser.add_argument("--keep-symlinks",
+                        action="store_true",
+                        help=("If set, the output archive stores symbolic "
+                              "links in the archive, instead of the file "
+                              "referred to by the link. This can avoid "
+                              "storing multiple copies of the same files. "
+                              "*Note that the resulting archive may silently "
+                              "fail on decompression if the ``unzip`` "
+                              "implementation doesn't support symlinks*. By "
+                              "default, the output archive stores the files "
+                              "referred by the links."))
     return parser
 
 
@@ -123,7 +126,8 @@ def main(args=None, pack=pack):
              zip_symlinks=args.zip_symlinks,
              zip_64=not args.no_zip_64,
              verbose=not args.quiet,
-             filters=args.filters)
+             filters=args.filters,
+             keep_symlinks=args.keep_symlinks)
     except VenvPackException as e:
         fail("VenvPackError: %s" % e)
     except KeyboardInterrupt:  # pragma: nocover


### PR DESCRIPTION
This PR:

- Adds `keep_symlinks` (`--keep-symlinks` in CLI) option disabled by default. By default, it will now copy the files referred by symbolic links.
- Deprecates `zip_symlinks` (`--zip-symlinks` in CLI) option that used to only work with `zip` format. Now it works with other formats too.

Resolves #5

The rationale here is:
- The downside is copying and it takes more time but we can make it it working everywhere, which is probably the main reason of packing a virtual environment, and also pretty important in distributed environments.
- Presumably most of issues related to the path and prefixes will go away by doing this.
- We can just simply copy by default first and incrementally whitelist the "safe" links like relative paths.

I added unittests and manually tested CLI after installing, for example:

```bash
venv-pack --keep-symlinks -o pyspark_venv-keep-symlinks.tar.gz
venv-pack --zip-symlinks -o pyspark_venv-zip_symlinks.tar.gz
venv-pack  -o pyspark_venv.tar.gz
```